### PR TITLE
[en-fr] Add English to French section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ en-eo
 en-es
 
 - [Wayne Boka](https://github.com/wboka)
+
+en-fr
+
+- [Andre Polykanine](https://github.com/Menelion)

--- a/_data/en-fr/basics.json
+++ b/_data/en-fr/basics.json
@@ -1,0 +1,14 @@
+[
+	{
+		"original_alternatives": ["Hi"],
+		"original": "Hello",
+		"translated_alternatives": ["Salut"],
+		"translated": "Bonjour"
+	},
+	{
+		"original_alternatives": ["Bye", "See you later", "See you soon"],
+		"original": "Goodbye",
+		"translated_alternatives": ["À bientôt"],
+		"translated": "Au revoir"
+	}
+]

--- a/_data/en-fr/numbers.json
+++ b/_data/en-fr/numbers.json
@@ -1,0 +1,154 @@
+[
+	{
+		"original": "One",
+		"translated": "Un"
+	},
+	{
+		"original": "Two",
+		"translated": "Deux"
+	},
+	{
+		"original": "Three",
+		"translated": "Trois"
+	},
+	{
+		"original": "Four",
+		"translated": "Quatre"
+	},
+	{
+		"original": "Five",
+		"translated": "Cinq"
+	},
+	{
+		"original": "Six",
+		"translated": "Six"
+	},
+	{
+		"original": "Seven",
+		"translated": "Sept"
+	},
+	{
+		"original": "Eight",
+		"translated": "Huit"
+	},
+	{
+		"original": "Nine",
+		"translated": "Neuf"
+	},
+	{
+		"original": "Ten",
+		"translated": "Dix"
+	},
+	{
+		"original": "Eleven",
+		"translated": "Onze"
+	},
+	{
+		"original": "Twelve",
+		"translated": "Douze"
+	},
+	{
+		"original": "Thirteen",
+		"translated": "Treize"
+	},
+	{
+		"original": "Fourteen",
+		"translated": "Quatorze"
+	},
+	{
+		"original": "Fifteen",
+		"translated": "Quinze"
+	},
+	{
+		"original": "Sixteen",
+		"translated": "Seize"
+	},
+{
+	"original": "Seventeen",
+	"translated": "Dix-sept"
+},
+{
+	"original": "Eighteen",
+		"translated": "Dix-huit"
+	},
+	{
+		"original": "Nineteen",
+		"translated": "Dix-neuf"
+	},
+	{
+		"original": "Twenty",
+		"translated": "Vingt"
+	},
+	{
+		"original": "Twenty-one",
+		"translated": "Vingt et un"
+	},
+	{
+		"original": "Twenty-two",
+		"translated": "Vingt-deux"
+	},
+	{
+		"original": "Twenty-three",
+		"translated": "Vingt-trois"
+	},
+	{
+		"original": "Thirty",
+		"translated": "Trente"
+	},
+	{
+		"original": "Forty",
+		"translated": "Quarante"
+	},
+	{
+		"original": "fifty",
+		"translated": "Cinquante"
+	},
+	{
+		"original": "Sixty",
+		"translated": "Soixante"
+	},
+	{
+		"original": "Sixty-nine",
+		"translated": "Soixante-neuf"
+	},
+	{
+		"original": "Seventy",
+		"translated": "Soixante-dix"
+	},
+	{
+		"original": "Seventy-one",
+		"translated": "Soixante et onze"
+	},
+	{
+		"original": "Seventy-nine",
+		"translated": "Soixante-dix-neuf"
+	},
+	{
+		"original": "Eighty",
+		"translated": "Quatre-vingts"
+	},
+	{
+		"original": "Eighty-one",
+		"translated": "Quatre-vingt-un"
+	},
+	{
+		"original": "Eighty-nine",
+		"translated": "Quatre-vingt-neuf"
+	},
+	{
+		"original": "Ninety",
+		"translated": "Quatre-vingt-dix"
+	},
+	{
+		"original": "Ninety-one",
+		"translated": "Quatre-vingt-onze"
+	},
+	{
+		"original": "Ninety-nine",
+		"translated": "Quatre-vingt-dix-neuf"
+	},
+	{
+		"original": "Hundred",
+		"translated": "Cent"
+	}
+	]


### PR DESCRIPTION
See #12.
Note that the Numbers section is a bit more detailed than in German due to the peculiarities of French counting: there are remnants of the Celtic vigesimal system, so 70 is "sixty-ten", 80 is "four twenties", and 90 is "four twenties and ten".

- [X] I solemnly swear that this is freely available content
- [X] Pull request title is prepended with `[lang-codes]`. Example `[en-eo]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *beginner or intermediate language learners*
- [X] Files are formatted according to [CONTRIBUTING.md](contributing.md)
  - [X] Yes, I have double-checked quotes and field names!
- [X]	New data follows one of the three available formats: json, csv, yml
