### PR TITLE
[en-pt] feature: Adding [animals.json]

### DIFF
--- a/_data/en-pt/animals.json
+++ b/_data/en-pt/animals.json
@@ -1,0 +1,81 @@
+[
+    {
+        "original": "Bird",
+        "translated": "Pássaro"
+    },
+    {
+        "original": "Fish",
+        "translated": "Peixe"
+    },
+    {
+        "original": "Mammals",
+        "translated": "Mamíferos"
+    },
+    {
+        "original": "Cow",
+        "translated": "Vaca"
+    },
+    {
+        "original": "Pig",
+        "translated": "Porco"
+    },
+    {
+        "original": "Chicken",
+        "translated": "Galinha"
+    },
+    {
+        "original": "Rooster",
+        "translated": "Galo"
+    },
+    {
+        "original": "Cat",
+        "translated": "Gato"
+    },
+    {
+        "original": "Dog",
+        "translated_alternatives": ["Cadela"],
+        "translated": "Cachorro"
+    },
+    {
+        "original": "Horse",
+        "translated": "Cavalo"
+    },
+    {
+        "original": "Bull",
+        "translated": "Touro"
+    },
+    {
+        "original": "Snake",
+        "translated_alternatives": ["Serpente"],
+        "translated": "Cobra"
+    },
+    {
+        "original": "Ant",
+        "translated": "Formiga"
+    },
+    {
+        "original": "Dove",
+        "translated": "Pomba"
+    },
+    {
+        "original": "Lion",
+        "translated": "Leão"
+    },
+    {
+        "original": "Monkey",
+        "translated": "Macaco"
+    },
+    {
+        "original": "Fox",
+        "translated": "Raposa"
+    },
+    {
+        "original": "Tiger",
+        "translated_alternatives": ["Tigresa"],
+        "translated": "Tigre"
+    },
+    {
+        "original": "Panther",
+        "translated": "Pantera"
+    }
+]


### PR DESCRIPTION
- [x] I solemnly swear that this is freely available content
- [x] Pull request title is prepended with `[lang-codes]`. Example `[en-eo]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *beginner or intermediate language learners*
- [x] Files are formatted according to [CONTRIBUTING.md](contributing.md)
  - [x] Yes, I have double-checked quotes and field names!
- [x]	New data follows one of the three available formats: json, csv, yml
